### PR TITLE
Add generic ERP catalog template scaffolding

### DIFF
--- a/static/[ENTITY_KEY]/[ENTITY_KEY].css
+++ b/static/[ENTITY_KEY]/[ENTITY_KEY].css
@@ -1,0 +1,67 @@
+/* Estilos comunes para catálogos */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--bs-primary);
+  color: #fff;
+  padding: 8px;
+  z-index: 1000;
+  text-decoration: none;
+}
+.skip-link:focus {
+  top: 0;
+}
+
+:focus-visible {
+  outline: 2px solid var(--bs-primary);
+  outline-offset: 2px;
+}
+
+.chip {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  background-color: var(--bs-secondary-bg);
+  border-radius: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  background-color: var(--bs-secondary-bg);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+}
+
+.table thead.sticky-top th {
+  background-color: var(--bs-body-bg);
+}
+
+.table-empty td {
+  color: var(--bs-secondary-color);
+}
+
+#offcanvasDetail {
+  width: 320px;
+}
+
+.btn,
+.form-check-input {
+  min-width: 44px;
+  min-height: 44px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/static/[ENTITY_KEY]/[ENTITY_KEY].js
+++ b/static/[ENTITY_KEY]/[ENTITY_KEY].js
@@ -1,0 +1,113 @@
+(function () {
+  const entityKey = '[ENTITY_KEY]';
+  const hiddenKey = entityKey + '.hiddenCols';
+  const table = document.getElementById(entityKey + '-table');
+  const selectAll = document.getElementById(entityKey + '-select-all');
+  const columnToggles = document.querySelectorAll('#' + entityKey + '-columns input[type="checkbox"]');
+  const offcanvasEl = document.getElementById('offcanvasDetail');
+  const offcanvas = offcanvasEl ? new bootstrap.Offcanvas(offcanvasEl) : null;
+  const liveRegion = document.getElementById(entityKey + '-filters-status');
+
+  // Atajos de teclado
+  document.addEventListener('keydown', function (e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    if (e.key === 'n' || e.key === 'N') {
+      window.location.href = '[CREATE_ROUTE]';
+    }
+    if (e.key === 'f' || e.key === 'F') {
+      const search = document.querySelector('#' + entityKey + '-filters input[name="search"]');
+      if (search) {
+        search.focus();
+      }
+    }
+    if (e.key === '?') {
+      const modal = document.getElementById('shortcutsModal');
+      if (modal) {
+        new bootstrap.Modal(modal).show();
+      }
+    }
+  });
+
+if (table) {
+  // Selección masiva
+  function updateSelection() {
+    const checked = table.querySelectorAll('tbody input[type="checkbox"]:checked');
+    const actions = document.querySelectorAll('[data-bulk-action]');
+    actions.forEach(btn => btn.disabled = checked.length === 0);
+  }
+  if (selectAll) {
+    selectAll.addEventListener('change', function () {
+      const boxes = table.querySelectorAll('tbody input[type="checkbox"]');
+      boxes.forEach(cb => cb.checked = selectAll.checked);
+      updateSelection();
+    });
+  }
+  table.addEventListener('change', function (e) {
+    if (e.target.matches('tbody input[type="checkbox"]')) {
+      updateSelection();
+    }
+  });
+
+  // Column toggles
+  const hiddenCols = JSON.parse(localStorage.getItem(hiddenKey) || '[]');
+  hiddenCols.forEach(name => {
+    const checkbox = document.querySelector('#' + entityKey + '-columns input[data-column="' + name + '"]');
+    if (checkbox) {
+      checkbox.checked = false;
+      toggleColumn(name, false);
+    }
+  });
+
+  function toggleColumn(name, visible) {
+    const cells = table.querySelectorAll('[data-col="' + name + '"]');
+    cells.forEach(c => c.classList.toggle('d-none', !visible));
+    announce('Columna ' + name + (visible ? ' visible' : ' oculta'));
+  }
+
+  columnToggles.forEach(cb => {
+    cb.addEventListener('change', function () {
+      toggleColumn(cb.dataset.column, cb.checked);
+      let stored = JSON.parse(localStorage.getItem(hiddenKey) || '[]');
+      if (!cb.checked) {
+        if (!stored.includes(cb.dataset.column)) stored.push(cb.dataset.column);
+      } else {
+        stored = stored.filter(i => i !== cb.dataset.column);
+      }
+      localStorage.setItem(hiddenKey, JSON.stringify(stored));
+    });
+  });
+
+  // Offcanvas detalle
+  document.querySelectorAll('.detail-trigger').forEach(btn => {
+    btn.addEventListener('click', function (e) {
+      const row = e.target.closest('tr');
+      const id = row.dataset.id;
+      const nameCell = row.querySelector('.' + entityKey + '-name');
+      if (!offcanvas) return;
+      // TODO: endpoint de detalle
+      fetch('/[ENTITY_NAME]/' + id + '/detail/')
+        .then(r => r.ok ? r.json() : Promise.reject())
+        .then(data => populateDetail(data))
+        .catch(() => {
+          populateDetail({
+            name: nameCell ? nameCell.textContent.trim() : '',
+          });
+        });
+      offcanvas.show();
+    });
+  });
+}
+
+  function populateDetail(data) {
+    const content = document.getElementById('offcanvasContent');
+    content.innerHTML = '<strong>' + (data.name || '') + '</strong>';
+    document.getElementById('offcanvasEdit').href = '[EDIT_ROUTE(:id)]'.replace(':id', data.id || '');
+    document.getElementById('offcanvasDelete').href = '[DELETE_ROUTE(':id)]'.replace(':id', data.id || '');
+  }
+
+  function announce(msg) {
+    if (liveRegion) {
+      liveRegion.textContent = msg;
+    }
+  }
+})();

--- a/templates/[ENTITY_KEY]_confirm.html
+++ b/templates/[ENTITY_KEY]_confirm.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Confirmar acción{% endblock %}
+{% block module_css %}
+<link rel="stylesheet" href="{% static '[ENTITY_KEY]/[ENTITY_KEY].css' %}" />
+{% endblock %}
+
+{% block content %}
+<a class="skip-link" href="#main-content">Saltar al contenido</a>
+<div class="container py-4" id="main-content">
+  <nav aria-label="Breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="[LIST_ROUTE]">[ENTITY_NAME]</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Confirmar</li>
+    </ol>
+  </nav>
+
+  <h1 class="h3 mb-3">Confirmar acción</h1>
+  <p>¿Está seguro de que desea <strong>[ACTION_NAME]</strong> este elemento?</p>
+
+  <form method="post" id="[ENTITY_KEY]-confirm-form">
+    {% csrf_token %}
+    <div class="mb-3">
+      <label for="reason" class="form-label">Motivo (opcional)</label>
+      <textarea id="reason" name="reason" class="form-control" rows="3"></textarea>
+    </div>
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" id="confirm-check" required />
+      <label class="form-check-label" for="confirm-check">Entiendo y deseo continuar</label>
+    </div>
+    <div class="d-flex justify-content-end gap-2 border-top pt-3">
+      <a href="[LIST_ROUTE]" class="btn btn-outline-secondary">Cancelar</a>
+      <button type="submit" class="btn btn-danger">Confirmar</button>
+    </div>
+  </form>
+</div>
+{% endblock %}
+{% block module_js %}
+<script src="{% static '[ENTITY_KEY]/[ENTITY_KEY].js' %}"></script>
+{% endblock %}

--- a/templates/[ENTITY_KEY]_form.html
+++ b/templates/[ENTITY_KEY]_form.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}[ENTITY_NAME] - Formulario{% endblock %}
+{% block module_css %}
+<link rel="stylesheet" href="{% static '[ENTITY_KEY]/[ENTITY_KEY].css' %}" />
+{% endblock %}
+
+{% block content %}
+<a class="skip-link" href="#main-content">Saltar al contenido</a>
+<div class="container py-4" id="main-content">
+  <nav aria-label="Breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="[LIST_ROUTE]">[ENTITY_NAME]</a></li>
+      <li class="breadcrumb-item active" aria-current="page">[FORM_ACTION]</li>
+    </ol>
+  </nav>
+
+  <h1 class="h3 mb-3">[FORM_ACTION] [ENTITY_NAME]</h1>
+
+  <form method="post" novalidate aria-describedby="form-errors" id="[ENTITY_KEY]-form">
+    {% csrf_token %}
+    <div id="form-errors" role="alert">
+      <!-- TODO: errores globales -->
+    </div>
+
+    <ul class="nav nav-tabs" id="[ENTITY_KEY]-tabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="basic-tab" data-bs-toggle="tab" data-bs-target="#basic" type="button" role="tab" aria-controls="basic" aria-selected="true">Perfil</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="perm-tab" data-bs-toggle="tab" data-bs-target="#perm" type="button" role="tab" aria-controls="perm" aria-selected="false">Permisos</button>
+      </li>
+    </ul>
+    <div class="tab-content pt-3">
+      <div class="tab-pane fade show active" id="basic" role="tabpanel" aria-labelledby="basic-tab">
+        <!-- TODO: campos de perfil/datos básicos -->
+        <div class="form-floating mb-3">
+          <input type="text" class="form-control" id="name" name="name" placeholder="Nombre" required />
+          <label for="name">Nombre</label>
+          <div class="invalid-feedback">Campo obligatorio.</div>
+        </div>
+        <div class="form-floating mb-3">
+          <input type="email" class="form-control" id="email" name="email" placeholder="Email" />
+          <label for="email">Email</label>
+        </div>
+      </div>
+      <div class="tab-pane fade" id="perm" role="tabpanel" aria-labelledby="perm-tab">
+        <!-- TODO: campos de permisos/estado -->
+        <div class="form-check form-switch mb-3">
+          <input class="form-check-input" type="checkbox" role="switch" id="is_active" name="is_active" />
+          <label class="form-check-label" for="is_active">Activo</label>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-actions border-top bg-body position-sticky bottom-0 py-3 mt-4 d-flex justify-content-end gap-2">
+      <a href="[LIST_ROUTE]" class="btn btn-outline-secondary">Cancelar</a>
+      <button type="submit" class="btn btn-primary">Guardar</button>
+    </div>
+  </form>
+</div>
+{% endblock %}
+{% block module_js %}
+<script src="{% static '[ENTITY_KEY]/[ENTITY_KEY].js' %}"></script>
+{% endblock %}

--- a/templates/[ENTITY_KEY]_list.html
+++ b/templates/[ENTITY_KEY]_list.html
@@ -1,0 +1,144 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}[ENTITY_NAME]{% endblock %}
+{% block module_css %}
+<link rel="stylesheet" href="{% static '[ENTITY_KEY]/[ENTITY_KEY].css' %}" />
+{% endblock %}
+
+{% block content %}
+<a class="skip-link" href="#main-content">Saltar al contenido</a>
+<section id="main-content" class="container-fluid py-4" aria-labelledby="[ENTITY_KEY]-heading">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+      <h1 id="[ENTITY_KEY]-heading" class="h3 mb-0">[ENTITY_NAME]</h1>
+      <p class="text-muted" aria-live="polite">Total: <span id="[ENTITY_KEY]-count">[TOTAL_COUNT]</span></p>
+    </div>
+    <div class="btn-group" role="group" aria-label="Acciones principales">
+      <a href="[CREATE_ROUTE]" class="btn btn-primary" accesskey="n"><i class="bi bi-plus-lg" aria-hidden="true"></i> <span class="visually-hidden">Nuevo</span></a>
+      <a href="[EXPORT_ROUTE]" class="btn btn-outline-secondary"><i class="bi bi-file-earmark-spreadsheet" aria-hidden="true"></i> <span class="visually-hidden">Exportar</span></a>
+      <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#shortcutsModal"><i class="bi bi-keyboard" aria-hidden="true"></i> <span class="visually-hidden">Atajos</span></button>
+    </div>
+  </div>
+
+  <!-- Filtros -->
+  <div class="card mb-3" aria-labelledby="[ENTITY_KEY]-filters-label">
+    <div class="card-header" id="[ENTITY_KEY]-filters-label">Filtros</div>
+    <div class="card-body">
+      <form method="get" class="row gy-2 gx-3 align-items-end" id="[ENTITY_KEY]-filters" aria-describedby="[ENTITY_KEY]-filters-status" aria-live="polite">
+        <!-- TODO: Reemplazar filtros -->
+        [FILTERS]
+        <div class="col-12 col-md-auto">
+          <label for="[ENTITY_KEY]-order" class="form-label">Ordenar por</label>
+          <select id="[ENTITY_KEY]-order" name="order" class="form-select">
+            [DEFAULT_SORT_OPTIONS]
+          </select>
+        </div>
+        <div class="col-12 col-md-auto">
+          <button type="submit" class="btn btn-primary">Aplicar</button>
+        </div>
+      </form>
+      <div id="[ENTITY_KEY]-filters-status" class="visually-hidden" aria-live="polite"></div>
+    </div>
+  </div>
+
+  <!-- Toolbar secundaria -->
+  <div class="d-flex justify-content-between align-items-center mb-2 flex-wrap gap-2" aria-label="Acciones masivas">
+    <div class="btn-group" role="group">
+      <!-- TODO: Acciones masivas -->
+      [BULK_ACTIONS]
+    </div>
+    <div class="btn-group">
+      <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="bi bi-layout-three-columns" aria-hidden="true"></i> Columnas
+      </button>
+      <ul class="dropdown-menu" id="[ENTITY_KEY]-columns" aria-labelledby="[ENTITY_KEY]-columns-label">
+        <!-- TODO: columnas -->
+        <li><label class="dropdown-item"><input class="form-check-input me-2" type="checkbox" data-column="col1" checked /> Columna 1</label></li>
+        <li><label class="dropdown-item"><input class="form-check-input me-2" type="checkbox" data-column="col2" checked /> Columna 2</label></li>
+        <li><label class="dropdown-item"><input class="form-check-input me-2" type="checkbox" data-column="col3" checked /> Columna 3</label></li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- Tabla -->
+  <div class="table-responsive">
+    <table class="table table-sm align-middle" id="[ENTITY_KEY]-table">
+      <caption class="visually-hidden">Listado de [ENTITY_NAME]</caption>
+      <thead class="sticky-top">
+        <tr>
+          <th scope="col" style="width: 44px"><input type="checkbox" id="[ENTITY_KEY]-select-all" class="form-check-input" /></th>
+          <!-- TODO: Encabezados -->
+          [COLUMNS]
+          <th scope="col" class="text-end">Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- TODO: iterar sobre objetos -->
+        <tr data-id="1">
+          <th scope="row"><input type="checkbox" class="form-check-input" /></th>
+          <td class="[ENTITY_KEY]-name"><button type="button" class="btn btn-link p-0 text-start detail-trigger" data-bs-toggle="offcanvas" data-bs-target="#offcanvasDetail" aria-controls="offcanvasDetail">Ejemplo nombre</button></td>
+          <td><span class="badge bg-success">Activo</span></td>
+          <td>
+            <span class="chip">Etiqueta 1</span>
+            <span class="chip">Etiqueta 2</span>
+          </td>
+          <td class="text-end">
+            <a href="[EDIT_ROUTE(1)]" class="btn btn-sm btn-outline-primary"><i class="bi bi-pencil" aria-hidden="true"></i><span class="visually-hidden">Editar</span></a>
+            <a href="[DELETE_ROUTE(1)]" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash" aria-hidden="true"></i><span class="visualmente-hidden">Borrar</span></a>
+          </td>
+        </tr>
+        <tr class="table-empty"><td colspan="99" class="text-center py-5">No hay registros</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Paginación -->
+  <nav aria-label="Paginación">
+    <ul class="pagination">
+      <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+      <li class="page-item active" aria-current="page"><span class="page-link">1</span></li>
+      <li class="page-item"><a class="page-link" href="#">2</a></li>
+      <li class="page-item"><a class="page-link" href="#">Siguiente</a></li>
+    </ul>
+  </nav>
+</section>
+
+<!-- Offcanvas detalle -->
+<div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasDetail" aria-labelledby="offcanvasDetailLabel">
+  <div class="offcanvas-header">
+    <h2 id="offcanvasDetailLabel" class="h5">Detalles</h2>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Cerrar"></button>
+  </div>
+  <div class="offcanvas-body">
+    <div id="offcanvasContent">Seleccione un registro.</div>
+    <div class="mt-3 d-flex gap-2">
+      <a href="#" class="btn btn-primary flex-fill" id="offcanvasEdit">Editar</a>
+      <a href="#" class="btn btn-outline-danger flex-fill" id="offcanvasDelete">Desactivar</a>
+    </div>
+  </div>
+</div>
+
+<!-- Modal de atajos -->
+<div class="modal" tabindex="-1" id="shortcutsModal" aria-labelledby="shortcutsModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 class="modal-title h5" id="shortcutsModalLabel">Atajos de teclado</h2>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body">
+        <ul>
+          <li><kbd>N</kbd>: Nuevo</li>
+          <li><kbd>F</kbd>: Buscar</li>
+          <li><kbd>?</kbd>: Ayuda</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+{% block module_js %}
+<script src="{% static '[ENTITY_KEY]/[ENTITY_KEY].js' %}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- scaffold accessible list view template with filters, column manager, offcanvas detail, and pagination
- add generic form and confirmation templates with breadcrumbs and sticky action bar
- include reusable CSS and JS for keyboard shortcuts, bulk actions, column toggles, and live regions

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68998c9f2b5c8330a3f2d7b33c02bceb